### PR TITLE
Support multiple outputs like json, spdx, yaml and 'human'

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ This Action wraps [`tern`](https://github.com/tern-tools/tern) allowing scanning
 
 **Required** docker image to scan. Example: `alpine:latest` 
 
+### `format`
+
+Output format. Can be either: `json`, `spdx` or `human`
+
+**Optional** defaults to `json`
+
+### `output`
+
+**Optional** Name of the output file
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This Action wraps [`tern`](https://github.com/tern-tools/tern) allowing scanning
 
 ### `format`
 
-Output format. Can be either: `json`, `spdx` or `human`
+Output format. Can be either: `json`, `spdxtagvalue`, `yaml` or `human`
 
 **Optional** defaults to `json`
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Output format. Can be either: `json`, `spdxtagvalue`, `yaml` or `human`
 
 ### `output`
 
-**Optional** Name of the output file
+**Optional** Name of the output file. Defaults to `tern.<format>`
 
 ## Outputs
 
@@ -64,6 +64,8 @@ jobs:
         id: scan
         with:
           image: alpine:latest
+          format: yaml
+          output: alpine.yaml
       - uses: actions/upload-artifact@v2
         with:
           name: tern 

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
     required: true
   format:
     description: "Output format"
-    default: "json"
+    default: 'json'
     required: false
   output:
     description: "Filenam Output"

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,13 @@ inputs:
   image:
     description: "The docker image to scan"
     required: true
+  format:
+    description: "Output format"
+    default: "json"
+    required: false
+  output:
+    description: "Filenam Output"
+    required: false
 
 outputs:
   output:

--- a/dist/index.js
+++ b/dist/index.js
@@ -1569,20 +1569,23 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(__webpack_require__(470));
 const exec_1 = __webpack_require__(986);
-const fs_1 = __webpack_require__(747);
 exports.tern = async () => {
     const image = core.getInput('image', { required: true });
     const prepareCommands = [
         `git clone https://github.com/tern-tools/tern.git`,
         `docker build . --file tern/Dockerfile --tag ternd`,
     ];
+    const outputFormat = "json";
+    const outputFile = `tern.${outputFormat}`;
     const ternCommands = [
-        `./tern/docker_run.sh workdir ternd "report -f json -i ${image}"`,
+        `./tern/docker_run.sh workdir ternd "report -f ${outputFormat} -i ${image} -o ${outputFile}"`,
     ];
     core.info(`
     Using Configuration:
 
     image             : ${image}
+    outputFormat      : ${outputFormat}
+    outputFile        : ${outputFile}
   `);
     core.startGroup('prepare tern environment');
     for (let index in prepareCommands) {
@@ -1611,19 +1614,8 @@ exports.tern = async () => {
         }
     }
     core.endGroup();
-    core.startGroup('Save output');
-    await fs_1.writeFile("tern.json", myOutput, (err) => {
-        if (err) {
-            core.setFailed('Write tern.json failed');
-            throw new Error('Write ten.json failed');
-        }
-        core.info(`Ouput written to tern.json`);
-    });
-    core.endGroup();
-    core.startGroup('collection output');
     core.setOutput('output', myOutput);
-    core.setOutput('file', "tern.json");
-    core.endGroup();
+    core.setOutput('file', outputFile);
 };
 
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -1569,6 +1569,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(__webpack_require__(470));
 const exec_1 = __webpack_require__(986);
+const fs_1 = __webpack_require__(747);
 exports.tern = async () => {
     const image = core.getInput('image', { required: true });
     const prepareCommands = [
@@ -1614,8 +1615,19 @@ exports.tern = async () => {
         }
     }
     core.endGroup();
+    core.startGroup('Save output');
+    await fs_1.writeFile(outputFile, myOutput, (err) => {
+        if (err) {
+            core.setFailed(`Write ${outputFile} failed`);
+            throw new Error(`Write ${outputFile} failed`);
+        }
+        core.info(`Ouput written to ${outputFile}`);
+    });
+    core.endGroup();
+    core.startGroup('collection output');
     core.setOutput('output', myOutput);
     core.setOutput('file', outputFile);
+    core.endGroup();
 };
 
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -1582,7 +1582,7 @@ exports.tern = async () => {
         'human'
     ];
     if (!allFormats.includes(outputFormat)) {
-        core.setFailed('Tern scan failed.');
+        core.setFailed('format does not match');
         throw new Error('Tern scan failed');
     }
     if (!outputFile) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1579,7 +1579,7 @@ exports.tern = async () => {
     const outputFormat = "json";
     const outputFile = `tern.${outputFormat}`;
     const ternCommands = [
-        `./tern/docker_run.sh workdir ternd "report -f ${outputFormat} -i ${image} -o ${outputFile}"`,
+        `./tern/docker_run.sh workdir ternd "report -f ${outputFormat} -i ${image}"`,
     ];
     core.info(`
     Using Configuration:

--- a/dist/index.js
+++ b/dist/index.js
@@ -1577,7 +1577,8 @@ exports.tern = async () => {
     let outputFile = core.getInput('output', { required: false });
     const allFormats = [
         'json',
-        'spdx',
+        'spdxtagvalue',
+        'yaml',
         'human'
     ];
     if (!allFormats.includes(outputFormat)) {
@@ -1609,8 +1610,9 @@ exports.tern = async () => {
     }
     core.endGroup();
     core.startGroup('Running tern scan');
+    const outputFormatParameter = outputFormat == 'human' ? '' : `-f ${outputFormat}`;
     const ternCommands = [
-        `./tern/docker_run.sh workdir ternd "report -f ${outputFormat} -i ${image}"`,
+        `./tern/docker_run.sh workdir ternd "report ${outputFormatParameter} -i ${image}"`,
     ];
     core.debug(`Running tern with the following commands: ${ternCommands.join(', ')}`);
     let myOutput = '';

--- a/src/tern.ts
+++ b/src/tern.ts
@@ -18,7 +18,7 @@ export const tern = async () => {
   ]
 
   if (!allFormats.includes(outputFormat)) {
-      core.setFailed('Tern scan failed.');
+      core.setFailed('format does not match');
       throw new Error('Tern scan failed');
   }
 

--- a/src/tern.ts
+++ b/src/tern.ts
@@ -12,7 +12,8 @@ export const tern = async () => {
   
   const allFormats: string[] = [
     'json',
-    'spdx',
+    'spdxtagvalue',
+    'yaml',
     'human'
   ]
 
@@ -51,9 +52,11 @@ export const tern = async () => {
   core.endGroup();
 
   core.startGroup('Running tern scan');
-  
+
+  const outputFormatParameter: string = outputFormat == 'human' ? '' : `-f ${outputFormat}` 
+
   const ternCommands: string[] = [
-    `./tern/docker_run.sh workdir ternd "report -f ${outputFormat} -i ${image}"`,
+    `./tern/docker_run.sh workdir ternd "report ${outputFormatParameter} -i ${image}"`,
   ];
 
   core.debug(

--- a/src/tern.ts
+++ b/src/tern.ts
@@ -1,5 +1,6 @@
 import * as core from '@actions/core';
 import { exec, ExecOptions } from '@actions/exec';
+import { writeFile } from 'fs';
 
 export const tern = async () => {
   const image = core.getInput('image', { required: true });
@@ -57,6 +58,20 @@ export const tern = async () => {
   }
   core.endGroup();
 
+  core.startGroup('Save output');
+  await writeFile(outputFile, myOutput, (err) => {
+    if (err) {
+        core.setFailed(`Write ${outputFile} failed`);
+        throw new Error(`Write ${outputFile} failed`);
+     }
+     core.info(
+       `Ouput written to ${outputFile}`
+     );
+  });
+  core.endGroup();
+
+  core.startGroup('collection output');
   core.setOutput('output', myOutput);
   core.setOutput('file', outputFile);
+  core.endGroup();
 };

--- a/src/tern.ts
+++ b/src/tern.ts
@@ -14,7 +14,7 @@ export const tern = async () => {
   const outputFile: string = `tern.${outputFormat}`;
 
   const ternCommands: string[] = [
-    `./tern/docker_run.sh workdir ternd "report -f ${outputFormat} -i ${image} -o ${outputFile}"`,
+    `./tern/docker_run.sh workdir ternd "report -f ${outputFormat} -i ${image}"`,
   ];
 
   core.info(`

--- a/src/tern.ts
+++ b/src/tern.ts
@@ -1,6 +1,5 @@
 import * as core from '@actions/core';
 import { exec, ExecOptions } from '@actions/exec';
-import { writeFile } from 'fs';
 
 export const tern = async () => {
   const image = core.getInput('image', { required: true });
@@ -9,15 +8,20 @@ export const tern = async () => {
     `git clone https://github.com/tern-tools/tern.git`,
     `docker build . --file tern/Dockerfile --tag ternd`,
   ];
-  
+ 
+  const outputFormat: string = "json"; 
+  const outputFile: string = `tern.${outputFormat}`;
+
   const ternCommands: string[] = [
-    `./tern/docker_run.sh workdir ternd "report -f json -i ${image}"`,
+    `./tern/docker_run.sh workdir ternd "report -f ${outputFormat} -i ${image} -o ${outputFile}"`,
   ];
 
   core.info(`
     Using Configuration:
 
     image             : ${image}
+    outputFormat      : ${outputFormat}
+    outputFile        : ${outputFile}
   `);
 
   core.startGroup('prepare tern environment');
@@ -53,21 +57,6 @@ export const tern = async () => {
   }
   core.endGroup();
 
-  core.startGroup('Save output');
-  await writeFile("tern.json", myOutput, (err) => {
-    if (err) {
-      core.setFailed('Write tern.json failed');
-      throw new Error('Write ten.json failed');
-    }
-    core.info(
-      `Ouput written to tern.json`
-    );
-  })
-  core.endGroup();
-
-  core.startGroup('collection output');
   core.setOutput('output', myOutput);
-  core.setOutput('file', "tern.json");
-
-  core.endGroup();
+  core.setOutput('file', outputFile);
 };


### PR DESCRIPTION
Tern supports the following four outputs:
- `json`
- `spdxtagvalue`
- `yaml`
- `human`

Now this can be passed in the action:

### `format`

Output format. Can be either: `json`, `spdxtagvalue`, `yaml` or `human`

**Optional** defaults to `json`

### `output`

**Optional** Name of the output file. Defaults to `tern.<format>`
