### PR TITLE
Use versioned image

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1600,7 +1600,7 @@ exports.tern = async () => {
     core.startGroup('Running tern scan');
     const outputFormatParameter = outputFormat == 'human' ? '' : `-f ${outputFormat}`;
     const ternCommands = [
-        `docker run --privileged --device /dev/fuse -v /var/run/docker.sock:/var/run/docker.sock --rm philipssoftware/tern:2.2.0 \"report ${outputFormatParameter} -i ${image}\"`,
+        `docker run --privileged --device /dev/fuse -v /var/run/docker.sock:/var/run/docker.sock --rm philipssoftware/tern:2.2.0 report ${outputFormatParameter} -i ${image}`,
     ];
     core.debug(`Running tern with the following commands: ${ternCommands.join(', ')}`);
     let myOutput = '';

--- a/dist/index.js
+++ b/dist/index.js
@@ -1597,23 +1597,10 @@ exports.tern = async () => {
     outputFile        : ${outputFile}
   `);
     core.endGroup();
-    core.startGroup('prepare tern environment');
-    const prepareCommands = [
-        `git clone https://github.com/tern-tools/tern.git`,
-        `docker build . --file tern/Dockerfile --tag ternd`,
-    ];
-    for (let index in prepareCommands) {
-        const errorCode = await exec_1.exec(prepareCommands[index]);
-        if (errorCode === 1) {
-            core.setFailed('Tern scan failed.');
-            throw new Error('Tern scan failed');
-        }
-    }
-    core.endGroup();
     core.startGroup('Running tern scan');
     const outputFormatParameter = outputFormat == 'human' ? '' : `-f ${outputFormat}`;
     const ternCommands = [
-        `./tern/docker_run.sh ternd \"report ${outputFormatParameter} -i ${image}\"`,
+        `docker run --privileged --device /dev/fuse -v /var/run/docker.sock:/var/run/docker.sock --rm philipssoftware/ternd:2.2.0 \"report ${outputFormatParameter} -i ${image}\"`,
     ];
     core.debug(`Running tern with the following commands: ${ternCommands.join(', ')}`);
     let myOutput = '';

--- a/dist/index.js
+++ b/dist/index.js
@@ -1600,7 +1600,7 @@ exports.tern = async () => {
     core.startGroup('Running tern scan');
     const outputFormatParameter = outputFormat == 'human' ? '' : `-f ${outputFormat}`;
     const ternCommands = [
-        `docker run --privileged --device /dev/fuse -v /var/run/docker.sock:/var/run/docker.sock --rm philipssoftware/ternd:2.2.0 \"report ${outputFormatParameter} -i ${image}\"`,
+        `docker run --privileged --device /dev/fuse -v /var/run/docker.sock:/var/run/docker.sock --rm philipssoftware/tern:2.2.0 \"report ${outputFormatParameter} -i ${image}\"`,
     ];
     core.debug(`Running tern with the following commands: ${ternCommands.join(', ')}`);
     let myOutput = '';

--- a/src/tern.ts
+++ b/src/tern.ts
@@ -36,28 +36,12 @@ export const tern = async () => {
   `);
   core.endGroup();
 
-  core.startGroup('prepare tern environment');
-
-  const prepareCommands: string[] = [
-    `git clone https://github.com/tern-tools/tern.git`,
-    `docker build . --file tern/Dockerfile --tag ternd`,
-  ];
-
-  for (let index in prepareCommands) {
-    const errorCode = await exec(prepareCommands[index]);
-    if (errorCode === 1 ) {
-      core.setFailed('Tern scan failed.');
-      throw new Error('Tern scan failed');
-    }
-  }
-  core.endGroup();
-
   core.startGroup('Running tern scan');
 
   const outputFormatParameter: string = outputFormat == 'human' ? '' : `-f ${outputFormat}` 
 
   const ternCommands: string[] = [
-    `./tern/docker_run.sh ternd \"report ${outputFormatParameter} -i ${image}\"`,
+    `docker run --privileged --device /dev/fuse -v /var/run/docker.sock:/var/run/docker.sock --rm philipssoftware/ternd:2.2.0 \"report ${outputFormatParameter} -i ${image}\"`,
   ];
 
   core.debug(

--- a/src/tern.ts
+++ b/src/tern.ts
@@ -41,7 +41,7 @@ export const tern = async () => {
   const outputFormatParameter: string = outputFormat == 'human' ? '' : `-f ${outputFormat}` 
 
   const ternCommands: string[] = [
-    `docker run --privileged --device /dev/fuse -v /var/run/docker.sock:/var/run/docker.sock --rm philipssoftware/tern:2.2.0 \"report ${outputFormatParameter} -i ${image}\"`,
+    `docker run --privileged --device /dev/fuse -v /var/run/docker.sock:/var/run/docker.sock --rm philipssoftware/tern:2.2.0 report ${outputFormatParameter} -i ${image}`,
   ];
 
   core.debug(

--- a/src/tern.ts
+++ b/src/tern.ts
@@ -41,7 +41,7 @@ export const tern = async () => {
   const outputFormatParameter: string = outputFormat == 'human' ? '' : `-f ${outputFormat}` 
 
   const ternCommands: string[] = [
-    `docker run --privileged --device /dev/fuse -v /var/run/docker.sock:/var/run/docker.sock --rm philipssoftware/ternd:2.2.0 \"report ${outputFormatParameter} -i ${image}\"`,
+    `docker run --privileged --device /dev/fuse -v /var/run/docker.sock:/var/run/docker.sock --rm philipssoftware/tern:2.2.0 \"report ${outputFormatParameter} -i ${image}\"`,
   ];
 
   core.debug(


### PR DESCRIPTION
Now it uses the `philipssoftware/tern:2.2.0` docker image instead of creating it yourself.

See https://github.com/JeroenKnoops/tern-action-examples/runs/1093559803?check_suite_focus=true for logs
Closes #12 